### PR TITLE
look for match with URL

### DIFF
--- a/background.html
+++ b/background.html
@@ -1,6 +1,7 @@
 <script src="jquery.min.js"></script>
 <script src="lscache.min.js"></script>
 <script src="snoowrap-v1.min.js"></script>
+<script src="URI.js"></script>
 <script src="shared.js"> </script>
 <script src="background.js"> </script>
 

--- a/background.js
+++ b/background.js
@@ -317,7 +317,7 @@ function backgroundSnoowrap() {
 
             urls.forEach(u => {
                 promises.push(
-                    fetch(comment_api + 'q=' + u)
+                    fetch(comment_api + 'q="' + URI.encode(u) + '"')
                     .then(response => response.json())
                     .then(resp => resp.data)
                     .then(data => data.map(elem => elem.link_id))  // array of submission IDs


### PR DESCRIPTION
Gets rid of the problem where pushshift would ignore everything after `?` in the URL and also would perform fuzzy matching.